### PR TITLE
List posts by user profile

### DIFF
--- a/Tabloid/Controllers/PostController.cs
+++ b/Tabloid/Controllers/PostController.cs
@@ -61,7 +61,7 @@ namespace Tabloid.Controllers
             {
                 return Ok(aprovedPost);
             }
-            else if (post != null && post.UserProfileId == currentUserProfile.Id)
+            else if (post != null && (post.UserProfileId == currentUserProfile.Id || currentUserProfile.UserTypeId == 1))
             {
                 return Ok(post);
             }

--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -26,15 +26,7 @@ namespace Tabloid.Controllers
         [HttpGet("getuserprofilebyid/{id}")]
         public IActionResult GetUserProfileById(int id)
         {
-            var userProfile = GetCurrentUserProfile();
-            if (userProfile.UserTypeId == 1)
-            {
                 return Ok(_userProfileRepository.GetByUserId(id));
-            }
-            else
-            {
-                return Unauthorized();
-            }
         }
 
         [HttpPost]

--- a/Tabloid/client/src/components/posts/Post.js
+++ b/Tabloid/client/src/components/posts/Post.js
@@ -6,11 +6,11 @@ import React, { useState, useContext, useEffect } from "react";
 
 const Post = ({ post }) => {
   const userProfileType = JSON.parse(sessionStorage.getItem("userProfile")).userTypeId;
+  const currentUserId = JSON.parse(sessionStorage.getItem("userProfile")).id;
   const { editPost, getAllPosts, getUserPost } = useContext(PostContext);
   const [postEdit, setEditPost] = useState();
   const { id } = useParams();
   let location = useLocation();
-
   useEffect(() => {
     setEditPost(post);
   }, []);
@@ -44,20 +44,22 @@ const Post = ({ post }) => {
           : <Button onClick={updatePost} color="success">Approve this Post</Button>
         }   </Card>
     )
-  }
-  return (
-    <Card className="m-4">
-      <p className="text-left px-2">Posted by: {post.userProfile.displayName}</p>
-      <CardBody>
-        <Link to={`/post/${post.id}`}>
-          <strong>{post.title}</strong>
-        </Link>
-      </CardBody>
-      <CardFooter>
-        Post Category: {post.category.name}
-      </CardFooter>
-    </Card>
-  );
+  } else if (post.isApproved === true || post.userProfile.id === currentUserId) {
+    return (
+      <Card className="m-4">
+        <p className="text-left px-2">Posted by: {post.userProfile.displayName}</p>
+        <CardBody>
+          <Link to={`/post/${post.id}`}>
+            <strong>{post.title}</strong>
+          </Link>
+        </CardBody>
+        <CardFooter>
+          Post Category: {post.category.name}
+        </CardFooter>
+      </Card>
+    );
+  } else
+    return ("")
 }
 
 export default Post;

--- a/Tabloid/client/src/components/posts/Post.js
+++ b/Tabloid/client/src/components/posts/Post.js
@@ -30,7 +30,7 @@ const Post = ({ post }) => {
   if (userProfileType == 1) {
     return (
       <Card className="m-4">
-        <p className="text-left px-2">Posted by: {post.userProfile.displayName}</p>
+        <p className="text-left px-2">Posted by: <Link to={`/user/${post.userProfileId}`}>{post.userProfile.displayName}</Link></p>
         <CardBody>
           <Link to={`/post/${post.id}`}>
             <strong>{post.title}</strong>
@@ -47,7 +47,7 @@ const Post = ({ post }) => {
   } else if (post.isApproved === true || post.userProfile.id === currentUserId) {
     return (
       <Card className="m-4">
-        <p className="text-left px-2">Posted by: {post.userProfile.displayName}</p>
+        <p className="text-left px-2">Posted by: <Link to={`/user/${post.userProfileId}`}>{post.userProfile.displayName}</Link></p>
         <CardBody>
           <Link to={`/post/${post.id}`}>
             <strong>{post.title}</strong>

--- a/Tabloid/client/src/components/posts/PostDetails.js
+++ b/Tabloid/client/src/components/posts/PostDetails.js
@@ -142,6 +142,12 @@ const PostDetails = () => {
                 : ""
             }
 
+            {
+              (post.isApproved === false)
+                ? <p>This post has not yet been approved by an admin and is only visible to you.</p>
+                : ""
+            }
+
           </ListGroup>
           {commentDisplay()}
 

--- a/Tabloid/client/src/components/posts/PostDetails.js
+++ b/Tabloid/client/src/components/posts/PostDetails.js
@@ -37,6 +37,9 @@ const PostDetails = () => {
       return (
         <div>
           <CommentList comments={post.comments} setPost={setPost} postId={post.id} />
+          {/* {
+            post.comments.map(c => <Comment key={c.id} comment={c} setPost={setPost} />)
+          } */}
         </div>
       )
     }
@@ -116,11 +119,12 @@ const PostDetails = () => {
             <ListGroupItem><strong>Content: </strong>{post.content}</ListGroupItem>
             <ListGroupItem><strong>Category</strong>: {post.category.name}</ListGroupItem>
             {
-              (post.publishDateTime === null)
+              (post.publishDateTime == null)
                 ? <ListGroupItem><strong>Posted: </strong>No publication date.</ListGroupItem>
                 : <ListGroupItem><strong>Posted: </strong>{formatedDate}</ListGroupItem>
             }
-            <ListGroupItem><strong>Posted By: </strong>{post.userProfile.displayName}</ListGroupItem>
+
+            <ListGroupItem><strong>Posted By: </strong><Link to={`/user/${post.userProfileId}`}>{post.userProfile.displayName}</Link></ListGroupItem>
             <ListGroupItem><div className="postTags"> <strong>Tags: </strong>  {post.postTags.map(pt => <TagsOnPost key={pt.id} postTag={pt} />)}</div></ListGroupItem>
 
             {

--- a/Tabloid/client/src/components/posts/UserPost.js
+++ b/Tabloid/client/src/components/posts/UserPost.js
@@ -1,20 +1,32 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { PostContext } from "../../providers/PostProvider";
 import Post from "./Post";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
 
 
 const UserPost = () => {
   const { posts, getUserPost } = useContext(PostContext);
+  const { getUserProfileById } = useContext(UserProfileContext);
+  const [userProfile, setUserProfile] = useState();
   const { id } = useParams();
 
   useEffect(() => {
-    getUserPost(id);
+    getUserProfileById(id).then(setUserProfile);
   }, []);
+
+  useEffect(() => {
+    getUserPost(id);
+  }, [id]);
+
+  if (!userProfile) {
+    return null;
+  }
 
   return (
     <div className="row justify-content-center">
       <div className="postList">
+        <h2>{userProfile.displayName}'s Posts</h2>
         <div className="cards-column">
           {posts.map((post) => (
             <Post key={post.id} post={post} />

--- a/Tabloid/client/src/components/tags/AddTag.js
+++ b/Tabloid/client/src/components/tags/AddTag.js
@@ -5,17 +5,12 @@ import { PostContext } from "../../providers/PostProvider";
 import { useParams } from "react-router-dom";
 
 
-export const AddTag = ({ tag }) => {
+export const AddTag = ({ tag, currentPost }) => {
 
     const { addTagtoPost, removeTagFromPost, getPost } = useContext(PostContext);
     const { id } = useParams();
 
-    const [post, setPost] = useState();
-
-    useEffect(() => {
-        getPost(parseInt(id)).then(setPost);
-    }, []);
-
+    const [post, setPost] = useState(currentPost);
 
     const addThisTag = (tagId) => {
         addTagtoPost({
@@ -24,10 +19,6 @@ export const AddTag = ({ tag }) => {
         }).then(() => {
             getPost(parseInt(id)).then(setPost)
         })
-    }
-
-    if (!post) {
-        return null;
     }
 
     return (

--- a/Tabloid/client/src/components/tags/AddTagForm.js
+++ b/Tabloid/client/src/components/tags/AddTagForm.js
@@ -1,15 +1,29 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { AddTag } from "./AddTag"
 import { TagContext } from "../../providers/TagProvider"
+import { useParams } from "react-router-dom";
+import { PostContext } from "../../providers/PostProvider";
 
 export const AddTagForm = () => {
 
     const { tags, getAllTags } = useContext(TagContext)
 
+    const { getPost } = useContext(PostContext);
+    const { id } = useParams();
+
+    const [post, setPost] = useState();
+
+    useEffect(() => {
+        getPost(parseInt(id)).then(setPost);
+    }, []);
+
     useEffect(() => {
         getAllTags();
     }, []);
 
+    if (!post) {
+        return null;
+    }
 
     return (
         <section>
@@ -19,7 +33,7 @@ export const AddTagForm = () => {
 
             <div className="tagsContainer">
                 {tags.map(t =>
-                    <AddTag key={t.id} tag={t} />)}
+                    <AddTag key={t.id} tag={t} currentPost={post} />)}
             </div>
 
         </section>

--- a/Tabloid/client/src/components/userProfile/UserProfileDetails.js
+++ b/Tabloid/client/src/components/userProfile/UserProfileDetails.js
@@ -43,7 +43,7 @@ export const UserProfileDetails = () => {
         userProfile.isActive = false;
         editUserProfile(parsedId, userProfile).then(() => {
             getUserProfileById(parsedId).then((resp) => {
-                if (resp.title === "Unauthorized") {
+                if (resp.id === parsedId) {
                     logout();
                 } else {
                     setUserProfile(resp);
@@ -79,7 +79,7 @@ export const UserProfileDetails = () => {
         userProfile.userTypeId = 2;
         editUserProfile(parsedId, userProfile).then(() => {
             getUserProfileById(parsedId).then((resp) => {
-                if (resp.title === "Unauthorized") {
+                if (resp.id === parsedId) {
                     logout();
                 } else {
                     setUserProfile(resp);


### PR DESCRIPTION
### Details
- Users can now click on another user's display name in a post to see a list of their posts
- Authors will not see unapproved posts on another user's profile page
- Admins can now see post details of unapproved posts

#### Small Changes
- Added a note for authors in post details that tells them if their post is currently unapproved
- Fixed the problem of tags being fetched individually when adding a tag to a post

### How to Test
- Click on another user's name to be directed to their profile
- Make sure that admins can see unapproved posts on a user's profile while authors cannot
- Make sure adding a tag to a post functionality still works


